### PR TITLE
add optional flag for workspace discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,18 +85,20 @@ uses Azure service discovery to find all workspaces in one or multiple subscript
 | `filter`       |                          | no       | no       | Advanced filter for `resource \| {filter} \| project id, customerId=properties.customerId` ResoruceGraph query (available with `23.6.0`) |
 | `cache`        |                          | no       | no       | Use of internal metrics caching (time.Duration)                                                                                          |
 | `parallel`     | `$LOGANALYTICS_PARALLEL` | no       | no       | Number (int) of how many workspaces can be queried at the same time                                                                      |
+| `optional`     | `false`                  | no       | no       | Do not fail, if service discovery did not find any workspaces                                                                            |
 
 ## Global metrics
 
 available on `/metrics`
 
-| Metric                                      | Description                                                                    |
-|---------------------------------------------|--------------------------------------------------------------------------------|
-| `azure_loganalytics_status`                 | Status if query was successfull (per workspace, module, metric)                |
-| `azure_loganalytics_last_query_successfull` | Timestamp of last successfull query (per workspace, module, metric)            |
-| `azure_loganalytics_query_time`             | Summary metric about query execution time (incl. all subqueries)               |
-| `azure_loganalytics_query_results`          | Number of results from query                                                   |
-| `azure_loganalytics_query_requests`         | Count of requests (eg paged subqueries) per query                              |
+| Metric                                      | Description                                                         |
+|---------------------------------------------|---------------------------------------------------------------------|
+| `azure_loganalytics_status`                 | Status if query was successfull (per workspace, module, metric)     |
+| `azure_loganalytics_last_query_successfull` | Timestamp of last successfull query (per workspace, module, metric) |
+| `azure_loganalytics_query_time`             | Summary metric about query execution time (incl. all subqueries)    |
+| `azure_loganalytics_query_results`          | Number of results from query                                        |
+| `azure_loganalytics_query_requests`         | Count of requests (eg paged subqueries) per query                   |
+| `azure_loganalytics_workspace_query_count`  | Count of discovered workspaces per module                           |
 
 ### AzureTracing metrics
 

--- a/loganalytics/global-metrics.go
+++ b/loganalytics/global-metrics.go
@@ -8,6 +8,7 @@ var (
 	prometheusQueryRequests        *prometheus.CounterVec
 	prometheusQueryStatus          *prometheus.GaugeVec
 	prometheusQueryLastSuccessfull *prometheus.GaugeVec
+	prometheusQueryWorkspaceCount  *prometheus.GaugeVec
 )
 
 func InitGlobalMetrics() {
@@ -72,5 +73,14 @@ func InitGlobalMetrics() {
 			"metric",
 		},
 	)
-	prometheus.MustRegister(prometheusQueryLastSuccessfull)
+	prometheusQueryWorkspaceCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "azure_loganalytics_workspace_query_count",
+			Help: "Azure loganalytics workspace query count",
+		},
+		[]string{
+			"module",
+		},
+	)
+	prometheus.MustRegister(prometheusQueryWorkspaceCount)
 }


### PR DESCRIPTION
We have a default config for each time using subscription discovery + filter. But sometime, if workspace list is empty which results into an error.